### PR TITLE
Dependencies update in README.rst for Ubuntu

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Install python 2.7:
 
 Needed libs:
 ::
-   apt-get install libxml2-dev libxslt1-dev expat python-dev eventlib-dev
+   apt-get install libxml2-dev libxslt1-dev expat python-dev eventlib-dev python-virtualenv
 
 If you want readthedocs to generate PDF files (be ware, lots of dependencies!):
 ::

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Install python 2.7:
 
 Needed libs:
 ::
-   apt-get install libxml2-dev libxslt1-dev expat python-dev eventlib-dev python-virtualenv
+   apt-get install libxml2-dev libxslt1-dev expat python-dev libevent-dev python-virtualenv
 
 If you want readthedocs to generate PDF files (be ware, lots of dependencies!):
 ::

--- a/README.rst
+++ b/README.rst
@@ -32,14 +32,14 @@ Install python 2.7:
 
 Needed libs:
 ::
-   apt-get install install libxml2-dev libxslt1-dev expat
+   apt-get install libxml2-dev libxslt1-dev expat python-dev
 
 If you want readthedocs to generate PDF files (be ware, lots of dependencies!):
 ::
    apt-get install texlive texlive-latex-extra
 
 
-   
+
 Install
 =======
 Boostrap buildout (using distribute):

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Install python 2.7:
 
 Needed libs:
 ::
-   apt-get install libxml2-dev libxslt1-dev expat python-dev
+   apt-get install libxml2-dev libxslt1-dev expat python-dev eventlib-dev
 
 If you want readthedocs to generate PDF files (be ware, lots of dependencies!):
 ::


### PR DESCRIPTION
Hi, my pull request fixes the dependencies needed for Ubuntu 11.10 (and possibly other versions)
- There is a typo the install is written twice.
- python-dev is needed when buildout wants to build Mercurial.
- eventlib-dev is needed when compiling memcached.
- python-virtualenv is highly recommended, because the server hosting rtd usualy doesn't have all the dependencies for projects.

I will report the dependency changes. 
We will soon migrate to Ubuntu 12.04 LTS.
